### PR TITLE
chore: pin CI actions and reuse docker-image-publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.24"
           cache: true
@@ -62,7 +62,7 @@ jobs:
         run: go build -v ./cmd/server
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Validate container build
         run: |
@@ -108,41 +108,13 @@ jobs:
 
   build-and-push:
     needs: [validate, golangci-lint, govulncheck, test]
-    runs-on: ubuntu-latest
     if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write
+      id-token: write
+    uses: actionsforge/actions/.github/workflows/docker-image-publish.yml@main
+    with:
+      platforms: linux/amd64,linux/arm64
+      scan-enabled: false
 
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/platformfuzz/go-hello-service
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Pin floating checkout/setup-go/buildx in the validate job to current majors (SHA)
- Replace inline multi-arch GHCR build/push with `actionsforge/actions` `docker-image-publish.yml` (`scan-enabled: false`)
- Closes the Dependabot major bumps for login/metadata/build-push via the reusable

## Test plan
- [ ] validate + lint/test jobs pass on PR
- [ ] push to main exercises docker-image-publish