### PR TITLE
chore: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-merge:
+    uses: actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `.github/workflows/auto-merge.yml` calling `actionsforge/actions` `dependabot-auto-merge` reusable
- Enables Dependabot PRs to auto-merge after checks when repo `allow_auto_merge` is on (public repos)

## Test plan
- [ ] Hygiene workflows pass on this PR
- [ ] Future Dependabot PRs get auto-merge armed when checks are green
