### PR TITLE
fix: pin golangci-lint action and clear gosec G706

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "platformfuzz"
-    assignees:
-      - "platformfuzz"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -18,7 +14,3 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "platformfuzz"
-    assignees:
-      - "platformfuzz"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   golangci-lint:
-    uses: actionsforge/actions-golangci-lint/.github/workflows/golangci-lint.yml@v0
+    uses: actionsforge/actions-golangci-lint/.github/workflows/golangci-lint.yml@v0.0.10
 
   govulncheck:
     uses: actionsforge/actions-govulncheck/.github/workflows/govulncheck.yml@v0.0.9

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -66,12 +67,12 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		// Call the next handler
 		next.ServeHTTP(w, r)
 
-		// Log the request
+		// Log the request (strip CR/LF to avoid log injection / gosec G706)
 		log.Printf(
 			"%s %s %s %v",
 			r.Method,
-			r.RequestURI,
-			r.RemoteAddr,
+			sanitizeLogField(r.URL.Path),
+			sanitizeLogField(r.RemoteAddr),
 			time.Since(start),
 		)
 	})
@@ -160,4 +161,8 @@ func getPort() string {
 		port = "8080"
 	}
 	return port
+}
+
+func sanitizeLogField(s string) string {
+	return strings.NewReplacer("\n", "", "\r", "").Replace(s)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -67,13 +67,12 @@ func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 		// Call the next handler
 		next.ServeHTTP(w, r)
 
-		// Log the request (strip CR/LF to avoid log injection / gosec G706)
-		log.Printf(
-			"%s %s %s %v",
-			r.Method,
-			sanitizeLogField(r.URL.Path),
-			sanitizeLogField(r.RemoteAddr),
-			time.Since(start),
+		// Structured logging avoids printf-style log injection (gosec G706).
+		slog.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote", r.RemoteAddr,
+			"duration", time.Since(start),
 		)
 	})
 }
@@ -161,8 +160,4 @@ func getPort() string {
 		port = "8080"
 	}
 	return port
-}
-
-func sanitizeLogField(s string) string {
-	return strings.NewReplacer("\n", "", "\r", "").Replace(s)
 }


### PR DESCRIPTION
## Summary
- Supersedes https://github.com/platformfuzz/go-hello-service/pull/39
- Pin `actions-golangci-lint` to `v0.0.10`
- Fix gosec `G706` log injection in request middleware
- Remove invalid `platformfuzz` assignees/reviewers from `dependabot.yml`

Closes #40

## Test plan
- [ ] `golangci-lint` green
- [ ] `test` / `govulncheck` / `validate` green
- [ ] Squash-merge (Dependabot auto-merge cannot update workflow files without `workflows` permission)