### PR TITLE
fix: use direct merge instead of github auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,4 +14,6 @@ permissions:
 jobs:
   auto-merge:
     uses: actionsforge/actions/.github/workflows/dependabot-auto-merge.yml@main
+    with:
+      use-github-auto-merge: false
     secrets: inherit


### PR DESCRIPTION
Branch protection is not configured on `main`, so `gh pr merge --auto` fails with:

```
Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
```

Switch to direct merge (`use-github-auto-merge: false`) which merges immediately once the workflow runs. This fixes the failing auto-merge check on Dependabot PRs like #43.